### PR TITLE
Add "Learn to Hack"

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,28 @@
               </p>
             </div>
           </div>
+
+          <div class="row mt-4 align-items-center border-bottom">
+            <div class="col-4">
+              <p>
+                <blockquote><strong>Learn to hack</strong></blockquote>
+                <caption>- nickmalcolm</caption>
+              </p>
+            </div>
+
+            <div class="col-8 text-left">
+              <p>
+                This workshop will get you started with 
+                <a href="https://owasp.org/www-project-juice-shop/">OWASP Juice
+                Shop</a>, an intentionally vulnerable web app you can self-host
+                and learn hacking skills on without getting in trouble.
+              </p>
+              <p>
+                Suitable for all skill levels. Just bring your laptop.
+              </p>
+            </div>
+          </div>
+          
         </div>
       </div>
 


### PR DESCRIPTION
I've put my hand up to run a workshop with OWASP Juice Shop at this year's Ruby Retreat.

I'll bring:

- Node binaries + Juice Shop binaries for various platforms
- Docker binaries & Juice Shop docker image (todo: figure out if this will even work with no internet...)
- OWASP ZAP binaries (optional)
- BurpSuite Community Edition binaries
- Firefox binaries just in case
- The JuiceShop Guidebook (incl. trainer guide & solutions)
- A copy of the OWASP website repository / the OWASP Top 10 & associated how-to guides
- Some pre-prepared slides on XSS & SQLi to get people started; probably 15-30 min of talking

People can pre-install it themselves before coming if they want :)

Format:

- People trust my USB drive and take what they need, installing Juice Shop and optional software
- People go at their own pace
- I'll give 15-30 min of talking for those that are interested in the help
- I'll stick around for at least another half hour (i.e. one hour total)


What do people think? Suggestions for improvement?